### PR TITLE
bugfix

### DIFF
--- a/sw.py
+++ b/sw.py
@@ -22,6 +22,7 @@ class SW():
             users = expense.getUsers()
             user_names = []
             expense_cost = float(expense.getCost())
+            is_append = False
 
             for user in users:
                 user_first_name = user.getFirstName()
@@ -36,13 +37,14 @@ class SW():
                         owed_expense['deleted_time'] = expense.getDeletedAt()
                         owed_expense['description'] = description
                         owed_expense['cost'] = expense_cost
+                        is_append = True
                 else:       # get user names other than current_user
                     paid_share = float(user.getPaidShare())
                     if paid_share == expense_cost:
                         user_names.append("[" + user_first_name + "]")
                     else:
                         user_names.append(user_first_name)
-            if paid == 0 and description.strip() != 'Payment':      # check category instead of description
+            if is_append:      # check category instead of description
                 owed_expense['users'] = user_names
                 owed_expenses.append(owed_expense)
         return owed_expenses


### PR DESCRIPTION
fixes the error:

`File "/home/runner/work/splitwise_ynab_sync/splitwise_ynab_sync/sw.py", line 45, in get_expenses`
`if paid == 0 and description.strip() != 'Payment':      # check category instead of description`
`UnboundLocalError: local variable 'paid' referenced before assignment`