### PR TITLE
Fix/change to updated date

### DIFF
--- a/main.py
+++ b/main.py
@@ -33,8 +33,8 @@ class ynab_splitwise_transfer():
             # process
             ynab_transactions = []
             for expense in expenses:
-                # don't import deleted expenses
-                if expense['deleted_time']:
+                # don't import deleted expenses OR repeat transactions (to avoid duplicates)
+                if expense['deleted_time'] or expense['repeat']:
                     continue
                 transaction = {
                                 "account_id": self.ynab_account_id,

--- a/main.py
+++ b/main.py
@@ -27,7 +27,7 @@ class ynab_splitwise_transfer():
     def sw_to_ynab(self):
         self.logger.info("Moving transactions from Splitwise to YNAB...")
         self.logger.info(f"Getting all Splitwise expenses from {self.sw_start_date} to {self.end_date}")
-        expenses = self.sw.get_expenses(dated_after=self.sw_start_date, dated_before=self.end_date)
+        expenses = self.sw.get_expenses(updated_after=self.sw_start_date, updated_before=self.end_date)
 
         if expenses:
             # process

--- a/sw.py
+++ b/sw.py
@@ -27,9 +27,11 @@ class SW():
             friends_ids.append(id)
         return friends_fullnames, friends_ids
 
-    def get_expenses(self, dated_before=None, dated_after=None):
+    def get_expenses(self, updated_before=None, updated_after=None):
         # get all expenses between 2 dates
-        expenses = self.sw.getExpenses(limit=self.limit, dated_before=dated_before, dated_after=dated_after)
+        expenses = self.sw.getExpenses(limit=self.limit, 
+                                       updated_before=updated_before, 
+                                       updated_after=updated_after)
         owed_expenses = []
         for expense in expenses:
             owed_expense = {}

--- a/sw.py
+++ b/sw.py
@@ -52,6 +52,7 @@ class SW():
                         owed_expense['updated_time'] = expense.getUpdatedAt()
                         owed_expense['deleted_time'] = expense.getDeletedAt()
                         owed_expense['description'] = description
+                        owed_expense['repeat'] = expense.isRepeat()
                         owed_expense['cost'] = expense_cost
                         is_append = True
                 else:       # get user names other than current_user


### PR DESCRIPTION
The new feature of Imported Transactions of Splitwise which imports expenses from Splitwise were not being synced to YNAB. The issue was that the date of Splitwise transaction reflects actual transaction date but the creation date is when the user creates the expense on Splitwise. To solve this, we need change the param of `get_expenses` from `dated_before` to `updated_before`.

With this change, we encounter duplicates for repeat expenses as one is the repeating instruction expense and the other is actual expense for the day. The code now excludes all expenses with `repeat=True` to get rid of duplicates.